### PR TITLE
specify more-itertools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask-Login==0.4.1
 Flask-PyMongo==2.3.0
 flask-restplus==0.13.0
 Flask-WTF==0.14.2
+more-itertools==5.0.0
 oauthlib==3.0.1
 pymongo==3.9.0
 requests==2.22.0


### PR DESCRIPTION
The EC2 instance is python 2.7 and this is the only module that is compatible with that. flask-restplus requires this module to run and if it's the incorrect version, then all hell will break loose.