### PR TITLE
Configure JWTManager to let API handle exceptions

### DIFF
--- a/application.py
+++ b/application.py
@@ -51,6 +51,7 @@ restApi.init_app(app)
 mail.init_app(app)
 executor.init_app(app)
 jwt.init_app(app)
+jwt._set_error_handler_callbacks(restApi)
 CORS(app, supports_credentials=True, resources={r"/*": {'origins': '*'}})
 
 client.client_id = app.config['GOOGLE_CLIENT_ID']


### PR DESCRIPTION
Without this line a 500 "internal server error" would get thrown instead of a proper 401.