### PR TITLE
Look up players by email as well as ID.

### DIFF
--- a/namespaces/Games.py
+++ b/namespaces/Games.py
@@ -342,7 +342,7 @@ class Game(Resource):
         playerIds = []
         for value in filteredPlayerIds:
             sendMail = False
-            player = UserModel.load_user_by_id(value)
+            player = UserModel.load_user_by_email(value) or UserModel.load_user_by_id(value)
             if player:
                 playerIds.append(player.id)
                 if player.id not in existingGame.playerIds:


### PR DESCRIPTION
If the FE is sending player emails as ids, then those could still be valid users in the system. No harm in leaving the lookup by ID method in case IDs are being sent for validation.