### PR TITLE
Provide response when joining game.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea/
 MANIFEST
 
 # PyInstaller

--- a/namespaces/Games.py
+++ b/namespaces/Games.py
@@ -599,4 +599,4 @@ class JoinGame(Resource):
                                         'for game ID: \'{}\' and user ID \'{}\'.'
                                         .format(gameId, current_user.id)), 500))
         
-        return make_response('', 200)
+        return make_response(jsonify(message='Successfully joined game: \'{}\''.format(game.gameName)), 200)


### PR DESCRIPTION
Having no response body creates an unnecessary special case that needs to be handled in the FE.