### PR TITLE
Make sure movies in game have release dates within game

### DIFF
--- a/namespaces/Games.py
+++ b/namespaces/Games.py
@@ -248,7 +248,8 @@ class Game(Resource):
         movies = []
         for movieId in game.movies:
             movieModel = MovieModel.load_movie_by_id(movieId)
-            movies.append(movieModel.__dict__)          
+            if arrow.get(game.startDate) <= arrow.get(movieModel.releaseDate) <= arrow.get(game.endDate):
+                movies.append(movieModel.__dict__)
             game.movies = movies
 
         playerIds = []


### PR DESCRIPTION
If a movie that was slated to be auctioned shifts its release date outside the auction dates, then it should not be available to auction. We don't remove the movie because it could technically slip back into the game window (rare, but possible).