### PR TITLE
Make userName firstName when person logs in for first time

### DIFF
--- a/namespaces/Authentication.py
+++ b/namespaces/Authentication.py
@@ -108,7 +108,7 @@ class loginValidate(Resource):
         if not storedUser:
             userModel = UserModel(
                 id=ObjectId(),
-                userHandle=userEmail.split('@')[0],
+                userHandle=firstName,
                 firstName=firstName,
                 lastName=lastName,
                 email=userEmail,


### PR DESCRIPTION
When playing the game it gets hard to remember who is who if you don't care about clever userNames. Default to first name since that is everyone's baseline and they can still change it if they want. The game is not built for strangers to play together yet.